### PR TITLE
fix: resolve scalar computer variant compilation issue

### DIFF
--- a/include/superkmeans/distance_computers/base_computers.h
+++ b/include/superkmeans/distance_computers/base_computers.h
@@ -25,7 +25,11 @@ class DistanceComputer {};
 
 template <>
 class DistanceComputer<DistanceFunction::l2, Quantization::f32> {
+#if !defined(__ARM_NEON) && !defined(__AVX2__) && !defined(__AVX512F__)
+    using computer = ScalarComputer<DistanceFunction::l2, Quantization::f32>;
+#else
     using computer = SIMDComputer<DistanceFunction::l2, Quantization::f32>;
+#endif
 
   public:
     constexpr static auto Horizontal = computer::Horizontal;
@@ -40,7 +44,11 @@ class DistanceComputer<DistanceFunction::l2, Quantization::f32> {
 
 template <Quantization q>
 class UtilsComputer {
+#if !defined(__ARM_NEON) && !defined(__AVX2__) && !defined(__AVX512F__)
+    using computer = ScalarUtilsComputer<q>;
+#else
     using computer = SIMDUtilsComputer<q>;
+#endif
 
   public:
     constexpr static auto FlipSign = computer::FlipSign;


### PR DESCRIPTION
## Problem

When a specialized SIMD computer is not included, then the fallback scalar computer is not used. This PR fixes the compiler error.

The PDXearch CI errors out when compiling on a machine that does not have any of the specialized computers' SIMD capabilities. https://github.com/Noorts/PDXearch/actions/runs/21988074192/job/63527403100?pr=3

```
<small snippet>
...
FAILED: extension/pdxearch/CMakeFiles/pdxearch_extension.dir/src/index/create/pdxearch_index_create_plan.cpp.o 
/usr/bin/ccache /opt/rh/gcc-toolset-14/root/usr/bin/c++ -DDUCKDB_BUILD_LIBRARY -DDUCKDB_CUSTOM_PLATFORM=linux_amd64 -DEIGEN_USE_BLAS -DEXT_VERSION_PDXEARCH=\"82c4071\" -I/duckdb_build_dir/duckdb/src/include -I/duckdb_build_dir/duckdb/third_party/fsst -I/duckdb_build_dir/duckdb/third_party/fmt/include -I/duckdb_build_dir/duckdb/third_party/hyperloglog -I/duckdb_build_dir/duckdb/third_party/fastpforlib -I/duckdb_build_dir/duckdb/third_party/skiplist -I/duckdb_build_dir/duckdb/third_party/ska_sort -I/duckdb_build_dir/duckdb/third_party/fast_float -I/duckdb_build_dir/duckdb/third_party/re2 -I/duckdb_build_dir/duckdb/third_party/miniz -I/duckdb_build_dir/duckdb/third_party/utf8proc/include -I/duckdb_build_dir/duckdb/third_party/concurrentqueue -I/duckdb_build_dir/duckdb/third_party/pcg -I/duckdb_build_dir/duckdb/third_party/pdqsort -I/duckdb_build_dir/duckdb/third_party/tdigest -I/duckdb_build_dir/duckdb/third_party/mbedtls/include -I/duckdb_build_dir/duckdb/third_party/jaro_winkler -I/duckdb_build_dir/duckdb/third_party/vergesort -I/duckdb_build_dir/duckdb/third_party/yyjson/include -I/duckdb_build_dir/duckdb/third_party/zstd/include -I/duckdb_build_dir/src/include -I/duckdb_build_dir/third_party/SuperKMeans/include -I/duckdb_build_dir/duckdb/third_party/libpg_query/include -isystem /duckdb_build_dir/build/release/vcpkg_installed/x64-linux-release/include/eigen3 -O3 -DNDEBUG -ffunction-sections -fdata-sections -O3 -DNDEBUG   -std=c++17 -fPIC -fdiagnostics-color=always -fopenmp -MD -MT extension/pdxearch/CMakeFiles/pdxearch_extension.dir/src/index/create/pdxearch_index_create_plan.cpp.o -MF extension/pdxearch/CMakeFiles/pdxearch_extension.dir/src/index/create/pdxearch_index_create_plan.cpp.o.d -o extension/pdxearch/CMakeFiles/pdxearch_extension.dir/src/index/create/pdxearch_index_create_plan.cpp.o -c /duckdb_build_dir/src/index/create/pdxearch_index_create_plan.cpp
In file included from /duckdb_build_dir/third_party/SuperKMeans/include/superkmeans/superkmeans.h:9,
                 from /duckdb_build_dir/src/include/index/pdxearch_kmeans.hpp:6,
                 from /duckdb_build_dir/src/include/index/pdxearch_wrapper.hpp:15,
                 from /duckdb_build_dir/src/include/index/pdxearch_index.hpp:10,
                 from /duckdb_build_dir/src/index/create/pdxearch_index_create_plan.cpp:10:
/duckdb_build_dir/third_party/SuperKMeans/include/superkmeans/distance_computers/base_computers.h:28:22: error: ‘SIMDComputer’ does not name a type; did you mean ‘ScalarComputer’?
   28 |     using computer = SIMDComputer<DistanceFunction::l2, Quantization::f32>;
      |                      ^~~~~~~~~~~~
      |                      ScalarComputer
/duckdb_build_dir/third_party/SuperKMeans/include/superkmeans/distance_computers/base_computers.h:31:40: error: ‘computer’ has not been declared
   31 |     constexpr static auto Horizontal = computer::Horizontal;
      |                                        ^~~~~~~~
/duckdb_build_dir/third_party/SuperKMeans/include/superkmeans/distance_computers/base_computers.h:43:22: error: ‘SIMDUtilsComputer’ does not name a type; did you mean ‘UtilsComputer’?
   43 |     using computer = SIMDUtilsComputer<q>;
      |                      ^~~~~~~~~~~~~~~~~
      |                      UtilsComputer

...
```

## Fix

I applied a fix similar to the one made to the PDX core: https://github.com/Noorts/PDXearch/commit/0b1af6ef6b135467f4e401d1879d713068d8f6e7.

I verified that the solution now compiles by manually disabling the SIMD computers, thus forcing the scalar implementation to be used.