### PR TITLE
Small optimization in FastAssign

### DIFF
--- a/benchmarks/ad_hoc_hierarchical_superkmeans.cpp
+++ b/benchmarks/ad_hoc_hierarchical_superkmeans.cpp
@@ -77,7 +77,7 @@ int main(int argc, char* argv[]) {
     config.ann_explore_fraction = 0.01f;
     config.unrotate_centroids = true;
     config.early_termination = false;
-    config.sampling_fraction = 0.3; // sampling_fraction;
+    config.sampling_fraction = 1.0f; // sampling_fraction;
     config.use_blas_only = false;
     config.tol = 1e-3f;
 

--- a/examples/simple_clustering.cpp
+++ b/examples/simple_clustering.cpp
@@ -50,5 +50,10 @@ int main(int argc, char* argv[]) {
     std::cout << "Index built in: " << construction_time_ms << " ms" << std::endl;
 
     // Get assignments
+    timer.Reset();
+    timer.Tic();
     std::vector<uint32_t> assignments = kmeans.Assign(data.data(), centroids.data(), n, k);
+    timer.Toc();
+    double assignment_time_ms = timer.GetMilliseconds();
+    std::cout << "Assignment time: " << assignment_time_ms << " ms" << std::endl;
 }

--- a/include/superkmeans/superkmeans.h
+++ b/include/superkmeans/superkmeans.h
@@ -508,6 +508,10 @@ class SuperKMeans {
             tmp_config.sampling_fraction = 1.0f;
             tmp_config.use_blas_only = false;
             tmp_config.verbose = config.verbose;
+            tmp_config.suppress_warnings = config.suppress_warnings;
+            tmp_config.seed = config.seed;
+            tmp_config.angular = config.angular;
+            tmp_config.data_already_rotated = config.data_already_rotated;
             auto new_n_centroids = static_cast<size_t>(std::sqrt(n_centroids));
             SuperKMeans tmp_kmeans(new_n_centroids, d, tmp_config);
             auto meso_centroids = tmp_kmeans.Train(centroids, n_centroids);


### PR DESCRIPTION
- For the FastAssign() we need to pass most of the same configs of the original clustering